### PR TITLE
The Right Configuration Panel now features two new toggle switches: “Grounding with Google Search” and “URL Context.”

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,20 @@
                 <label for="max-length-input">Max Output Tokens</label>
                 <input type="number" id="max-length-input" value="8192" class="form-control">
             </div>
+            <div class="form-group">
+                <label for="google-search-switcher">Grounding with Google Search</label>
+                <label class="switch" title="Toggle Google Search Grounding">
+                    <input type="checkbox" id="google-search-switcher">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="form-group">
+                <label for="url-context-switcher">URL Context</label>
+                <label class="switch" title="Toggle URL Context">
+                    <input type="checkbox" id="url-context-switcher">
+                    <span class="slider"></span>
+                </label>
+            </div>
         </aside>
     </div>
 


### PR DESCRIPTION
Introduced two new toggle switches in the Right Configuration Panel:
- "Grounding with Google Search"
- "URL Context"

Both switches are off by default, and I'll remember your preference for them.

When you enable "Grounding with Google Search", I'll be able to use Google Search to inform my responses.

When you enable "URL Context", I'll be able to consider the context of URLs you provide.

If you enable both, I'll use both capabilities.

Here's a summary of the code changes I made:
- I updated `index.html` to add the new switcher elements in the config panel.
- I updated `script.js`:
    - I added DOM references for the new switchers.
    - I added default values for these settings in `settingsManager`.
    - I updated `updateSettingsUI` to reflect the switcher states.
    - I added event listeners to save your switcher preferences.
    - I modified `getAIResponse` so I can dynamically adjust how I gather information based on your selections.