### PR TITLE
feat: Add Thinking Controls to Configuration Panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,24 @@
                     <span class="slider"></span>
                 </label>
             </div>
+            <div class="form-group form-group-inline">
+                <label>Thinking</label>
+                <label class="switch" title="Toggle Thinking">
+                    <input type="checkbox" id="thinking-switcher">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="form-group form-group-inline">
+                <label>Dynamic thinking</label>
+                <label class="switch" title="Toggle Dynamic Thinking">
+                    <input type="checkbox" id="dynamic-thinking-switcher">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="form-group">
+                <label for="thinking-budget-slider">Thinking budget: <span id="thinking-budget-value">0</span></label>
+                <input type="range" id="thinking-budget-slider" min="0" max="24576" step="1" value="0" class="slider-range">
+            </div>
         </aside>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -499,6 +499,16 @@ pre code.hljs {
     font-size: 0.9rem;
     margin-bottom: 0.5rem;
 }
+/* For aligning label and control (e.g., switch) on the same line */
+.form-group.form-group-inline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.form-group.form-group-inline label:not(.switch) { /* Target the text label, not the switch itself */
+    margin-bottom: 0; /* Remove bottom margin if inline */
+    margin-right: 0.5rem; /* Add some space between label and control */
+}
 .form-group input[type="text"],
 .form-group input[type="password"],
 .form-group input[type="number"],
@@ -788,6 +798,30 @@ input:checked + .slider {
 }
 input:checked + .slider:before {
   transform: translateX(14px);
+}
+input:disabled + .slider {
+  background-color: #ccc; /* Default grey for disabled slider */
+  cursor: not-allowed;
+}
+.dark-theme input:disabled + .slider {
+  background-color: #555; /* Darker grey for dark theme */
+}
+input:disabled + .slider:before {
+  background-color: #eee; /* Lighter circle for disabled slider */
+}
+.dark-theme input:disabled + .slider:before {
+  background-color: #404040; /* Darker circle for dark theme */
+}
+
+/* Styles for range sliders */
+.slider-range {
+    width: 100%; /* Ensure it takes full width within its container */
+    cursor: pointer;
+}
+
+.slider-range:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
 


### PR DESCRIPTION
This commit introduces new UI controls in the right configuration panel to manage the "Thinking" feature for Gemini API requests.

New controls:
- "Thinking" On/Off Switcher: Enables or disables the thinking feature. Default is Off. (API: thinkingBudget=0 for Off)
- "Dynamic thinking" On/Off Switcher: When "Thinking" is On, this allows for dynamic thinking. (API: thinkingBudget=-1 for On)
- "Thinking budget" Slider (0-24576): When "Thinking" is On and "Dynamic thinking" is Off, this slider sets a specific budget.

Changes include:
- `index.html`: Added HTML structure for the new switchers and slider.
- `script.js`:
    - Updated DOM element references.
    - Added new settings to `settingsManager` for persistence.
    - Implemented event listeners for new controls to manage their state and interdependencies (e.g., "Dynamic thinking" and "Thinking budget" are disabled if "Thinking" is Off).
    - Modified `getAIResponse` to construct the `thinkingConfig.thinkingBudget` parameter based on the UI controls' state and include it in the API request.
- `style.css`:
    - Added a `.form-group-inline` utility class for better label-control alignment.