### PR TITLE
Add close and open functionality to the left sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <div class="app-container">
         <!-- FR2: CONVERSATION MANAGEMENT (SIDEBAR) -->
         <aside class="sidebar">
-            <header class="panel-header">gChat</header>
+            <header class="panel-header"><span>gChat</span><button id="close-sidebar-btn" class="btn-icon-header" title="Close Panel">&times;</button></header>
             <button id="new-chat-btn" class="btn btn-primary new-chat-btn">New Chat</button>
             <div class="search-bar-container">
                 <input type="search" id="search-chats-input" placeholder="Search chats...">
@@ -35,6 +35,19 @@
         <main class="main-content">
             <div class="chat-header">
                  <div class="chat-header-controls">
+                    <button id="open-sidebar-btn" class="header-btn" title="Open Menu" style="display: none;">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="3" y1="12" x2="21" y2="12"></line>
+                            <line x1="3" y1="6" x2="21" y2="6"></line>
+                            <line x1="3" y1="18" x2="21" y2="18"></line>
+                        </svg>
+                    </button>
+                    <button id="speed-new-chat-btn" class="header-btn" title="New Chat" style="display: none;">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="12" y1="5" x2="12" y2="19"></line>
+                            <line x1="5" y1="12" x2="19" y2="12"></line>
+                        </svg>
+                    </button>
                     <button id="copy-chat-btn" class="header-btn" title="Copy Chat to Markdown">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
                     </button>

--- a/script.js
+++ b/script.js
@@ -35,6 +35,9 @@ const dom = {
     sidebar: document.querySelector('.sidebar'),
     mainContent: document.querySelector('.main-content'),
     configPanel: document.querySelector('.config-panel'),
+    closeSidebarBtn: document.getElementById('close-sidebar-btn'),
+    openSidebarBtn: document.getElementById('open-sidebar-btn'),
+    speedNewChatBtn: document.getElementById('speed-new-chat-btn'),
     
     // Chat
     chatWindow: document.querySelector('.chat-window'),
@@ -1136,6 +1139,27 @@ function setupEventListeners() {
     }
 
     setupGeneralAndChatSettingsListeners();
+
+    // Left Sidebar specific listeners
+    if (dom.closeSidebarBtn && dom.sidebar && dom.openSidebarBtn && dom.speedNewChatBtn) {
+        dom.closeSidebarBtn.addEventListener('click', () => {
+            dom.sidebar.classList.add('collapsed');
+            dom.openSidebarBtn.style.display = 'block';
+            dom.speedNewChatBtn.style.display = 'block';
+        });
+    }
+
+    if (dom.openSidebarBtn && dom.sidebar && dom.speedNewChatBtn) {
+        dom.openSidebarBtn.addEventListener('click', () => {
+            dom.sidebar.classList.remove('collapsed');
+            dom.openSidebarBtn.style.display = 'none';
+            dom.speedNewChatBtn.style.display = 'none';
+        });
+    }
+
+    if (dom.speedNewChatBtn) {
+        dom.speedNewChatBtn.addEventListener('click', createNewChat);
+    }
 }
 
 function setupGeneralAndChatSettingsListeners() {

--- a/style.css
+++ b/style.css
@@ -107,6 +107,13 @@ html, body {
   overflow-y: auto;
 }
 
+.sidebar.collapsed {
+    width: 0;
+    padding: 0; /* Ensure no padding when collapsed */
+    overflow: hidden;
+    border-right: none; /* Hide border when collapsed if desired */
+}
+
 .main-content {
   flex: 1;
   display: flex;
@@ -891,6 +898,7 @@ input:disabled + .slider:before {
 .toast-notification.info { background-color: #2196F3; }
 .toast-notification.success { background-color: #4CAF50; }
 .toast-notification.error { background-color: #f44336; }
+
 
 /* --- Responsive Design --- */
 @media (max-width: 1024px) {


### PR DESCRIPTION
This commit introduces the following changes:

- Adds an 'x' button to the left panel header to close it.
- When the left panel is closed, an 'Open Menu' button and a 'New Chat' (speed button) become visible at the top-left of your screen.
- Clicking 'Open Menu' expands the left panel and hides these two buttons.
- Clicking the 'x' button collapses the left panel and shows the two buttons.
- The 'New Chat' speed button allows for quick chat creation when the panel is closed.

HTML, CSS, and JavaScript files were modified to implement this behavior, mirroring patterns used for the right configuration panel.