### PR TITLE
feat: Add 'Disable thinking' switcher to control thinkingConfig

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,13 @@
                 </label>
             </div>
             <div class="form-group form-group-inline">
+                <label for="disable-thinking-switcher">Disable thinking (for thinking models)</label>
+                <label class="switch" title="Toggle Disable Thinking">
+                    <input type="checkbox" id="disable-thinking-switcher">
+                    <span class="slider"></span>
+                </label>
+            </div>
+            <div class="form-group form-group-inline">
                 <label>Thinking</label>
                 <label class="switch" title="Toggle Thinking">
                     <input type="checkbox" id="thinking-switcher">


### PR DESCRIPTION
This commit introduces a new switcher in the configuration panel: "Disable thinking (for thinking models)".

- The switcher is located above the existing "Thinking" switcher and defaults to OFF.
- If "Disable thinking" is ON, the request payload will include `thinkingConfig: { "thinkingBudget": 0 }`, overriding other thinking-related settings.
- If "Disable thinking" is OFF and the main "Thinking" switcher is also OFF, no `thinkingConfig` object is added to the request. This changes the previous behavior where `thinkingConfig: { "thinkingBudget": 0 }` was always added if the "Thinking" switch was off.
- If "Disable thinking" is OFF and the main "Thinking" switcher is ON, the existing logic for "Dynamic thinking" and "Thinking budget" applies.

The changes include:
- HTML modifications in `index.html` for the new switcher.
- JavaScript updates in `script.js` to:
    - Add the new DOM element and corresponding setting.
    - Update UI based on the setting.
    - Save the setting on change.
    - Modify `getAIResponse()` to implement the new logic for `thinkingConfig`.