### PR TITLE
Fix: Correctly display 'Unarchive' for archived chats

### DIFF
--- a/script.js
+++ b/script.js
@@ -1493,6 +1493,16 @@ function showChatItemMenu(button, chat) {
     menu.querySelector('[data-action="pin"]').style.display = chat.isPinned ? 'none' : 'block';
     menu.querySelector('[data-action="unpin"]').style.display = chat.isPinned ? 'block' : 'none';
 
+    // Configure Archive/Unarchive button
+    const archiveMenuItem = menu.querySelector('[data-action="archive"]');
+    if (chat.isArchived) {
+        archiveMenuItem.textContent = 'Unarchive';
+        archiveMenuItem.dataset.action = 'unarchive';
+    } else {
+        archiveMenuItem.textContent = 'Archive';
+        archiveMenuItem.dataset.action = 'archive';
+    }
+
     // Populate "Move to" sub-menu
     const subMenu = menu.querySelector('.sub-menu');
     const folders = settingsManager.getFolders();
@@ -1520,7 +1530,13 @@ function showChatItemMenu(button, chat) {
     menu.querySelector('[data-action="rename"]').onclick = () => handleChatItemAction('rename', chat);
     menu.querySelector('[data-action="pin"]').onclick = () => handleChatItemAction('pin', chat);
     menu.querySelector('[data-action="unpin"]').onclick = () => handleChatItemAction('unpin', chat);
-    menu.querySelector('[data-action="archive"]').onclick = () => handleChatItemAction('archive', chat);
+    // Listener for Archive/Unarchive will be dynamic due to action change
+    if (menu.querySelector('[data-action="archive"]')) {
+        menu.querySelector('[data-action="archive"]').onclick = () => handleChatItemAction('archive', chat);
+    }
+    if (menu.querySelector('[data-action="unarchive"]')) {
+        menu.querySelector('[data-action="unarchive"]').onclick = () => handleChatItemAction('unarchive', chat);
+    }
     menu.querySelector('[data-action="delete"]').onclick = () => handleChatItemAction('delete', chat);
     menu.querySelector('[data-action="export-md"]').onclick = () => handleChatItemAction('export-md', chat);
     menu.querySelector('[data-action="export-json"]').onclick = () => handleChatItemAction('export-json', chat);
@@ -1557,6 +1573,9 @@ async function handleChatItemAction(action, chat, options = {}) {
             break;
         case 'archive':
             chatUpdate.isArchived = true;
+            break;
+        case 'unarchive': // Added unarchive action
+            chatUpdate.isArchived = false;
             break;
         case 'move':
             chatUpdate.folderId = options.folderId;


### PR DESCRIPTION
The 3-dot menu for chat items was always displaying "Archive", even for chats that were already in the Archive section.

This commit updates the menu logic:
- If a chat is archived, the menu item now displays "Unarchive".
- Clicking "Unarchive" moves the chat to the History section and updates its status to a regular (unarchived) chat.
- If a chat is not archived, the menu item continues to display "Archive".

The `showChatItemMenu` function was modified to dynamically set the menu item text and action based on the chat's `isArchived` status. The `handleChatItemAction` function was updated to include a case for the "unarchive" action.
The `renderChatHistory` function did not require changes as its existing logic correctly handles the display of chats based on their `isArchived` property.