### PR TITLE
Update 'New Chat' button icons for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,14 @@
         <!-- FR2: CONVERSATION MANAGEMENT (SIDEBAR) -->
         <aside class="sidebar">
             <header class="panel-header"><span>gChat</span><button id="close-sidebar-btn" class="btn-icon-header" title="Close Panel">&times;</button></header>
-            <button id="new-chat-btn" class="btn btn-primary new-chat-btn">New Chat</button>
+            <button id="new-chat-btn" class="btn btn-primary new-chat-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-message-square-plus">
+                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                    <line x1="12" y1="7" x2="12" y2="13"></line>
+                    <line x1="9" y1="10" x2="15" y2="10"></line>
+                </svg>
+                <span>New Chat</span>
+            </button>
             <div class="search-bar-container">
                 <input type="search" id="search-chats-input" placeholder="Search chats...">
             </div>
@@ -43,9 +50,10 @@
                         </svg>
                     </button>
                     <button id="speed-new-chat-btn" class="header-btn" title="New Chat" style="display: none;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <line x1="12" y1="5" x2="12" y2="19"></line>
-                            <line x1="5" y1="12" x2="19" y2="12"></line>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-message-square-plus">
+                            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                            <line x1="12" y1="7" x2="12" y2="13"></line>
+                            <line x1="9" y1="10" x2="15" y2="10"></line>
                         </svg>
                     </button>
                     <button id="copy-chat-btn" class="header-btn" title="Copy Chat to Markdown">

--- a/style.css
+++ b/style.css
@@ -549,8 +549,18 @@ pre code.hljs {
 .new-chat-btn {
     width: 100%;
     margin-bottom: 1rem;
-    text-align: left;
+    /* text-align: left; */ /* Will be controlled by flex */
+    display: flex; /* Use flex to align icon and text */
+    align-items: center; /* Vertically align icon and text */
+    gap: 0.5rem; /* Space between icon and text */
 }
+
+.new-chat-btn svg {
+    width: 18px; /* Slightly smaller icon for a button with text */
+    height: 18px;
+    flex-shrink: 0; /* Prevent icon from shrinking */
+}
+
 .search-bar-container {
     margin-bottom: 1rem;
 }


### PR DESCRIPTION
- Replaced the simple '+' icon on the compact 'New Chat' button (speed-new-chat-btn) with a more descriptive 'message-square-plus' SVG icon.
- Added the same 'message-square-plus' SVG icon to the sidebar 'New Chat' button (new-chat-btn) for consistency.
- Adjusted CSS to ensure proper alignment and sizing of the icon within the sidebar button.