### PR TITLE
Fix: Settings button position in left panel on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
             <div id="chat-history-container" class="panel-section chat-history-list">
                 <!-- Folders and chat history will be rendered here by JS -->
             </div>
-            <div style="margin-top: auto;">
+            <div class="sidebar-footer-actions">
                 <button id="open-settings-btn" class="btn" style="width:100%;">Settings</button>
             </div>
         </aside>

--- a/style.css
+++ b/style.css
@@ -466,6 +466,10 @@ pre code.hljs {
 }
 
 /* --- Sidebar & Config Panel Common Styles --- */
+.sidebar-footer-actions {
+  margin-top: auto; /* Pushes to bottom on larger screens */
+}
+
 .panel-header {
     display: flex; /* Use flexbox for alignment */
     justify-content: space-between; /* Pushes title and button apart */
@@ -1001,5 +1005,9 @@ input:disabled + .slider:before {
     .chat-window {
         padding: 1rem;
         padding-top: 60px; /* Restored */
+    }
+
+    .sidebar-footer-actions {
+        margin-top: 1rem; /* Adjust as needed for spacing */
     }
 }


### PR DESCRIPTION
Removed inline style for margin-top on the sidebar footer actions div. Introduced a new class `sidebar-footer-actions`.
CSS updated to apply `margin-top: auto` for desktop and `margin-top: 1rem` for mobile, ensuring the settings button is not pushed to the bottom of the content on smaller screens.