### PR TITLE
Fix: Ensure Settings button stays at bottom of sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -980,10 +980,11 @@ input:disabled + .slider:before {
     }
     .sidebar {
         width: 100%; /* Takes full width when not collapsed */
-        height: auto;
+        height: 100vh; /* Ensure full viewport height */
         border-right: none;
         border-bottom: 1px solid var(--border-color);
         /* display: none; <-- REMOVED: Visibility will be controlled by .collapsed */
+        /* display: flex and flex-direction: column are inherited, allowing footer to be pushed down */
     }
     .sidebar.collapsed {
         width: 0 !important;


### PR DESCRIPTION
Modified the CSS for the sidebar to maintain 100vh height on smaller screens (<= 768px width). This ensures that the left panel occupies the full viewport height, allowing the internal flexbox layout to correctly position the Settings button at the bottom, even when there are few or no chats.