### PR TITLE
Replace prompt() with custom input modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,24 @@
             </div>
         </div>
     </div>
+
+    <!-- Custom Input Modal -->
+    <div id="custom-input-modal" class="modal-overlay">
+        <div class="modal-content" style="max-width: 400px; height: auto;">
+            <div class="modal-header">
+                <h2 id="custom-input-modal-title">Input Required</h2>
+                <button id="custom-input-modal-close-btn" class="btn">&times;</button>
+            </div>
+            <div class="modal-body" style="padding: 1.5rem; flex-direction: column;">
+                <label id="custom-input-modal-label" for="custom-input-modal-field" style="margin-bottom: 0.5rem; display: block;">Enter value:</label>
+                <input type="text" id="custom-input-modal-field" class="form-control" style="margin-bottom: 1rem;">
+                <div style="display: flex; justify-content: flex-end; gap: 0.5rem;">
+                    <button id="custom-input-modal-cancel-btn" class="btn">Cancel</button>
+                    <button id="custom-input-modal-ok-btn" class="btn btn-primary">OK</button>
+                </div>
+            </div>
+        </div>
+    </div>
     
     <!-- TEMPLATES -->
     <template id="message-template">

--- a/style.css
+++ b/style.css
@@ -935,6 +935,36 @@ input:disabled + .slider:before {
 }
 
 
+/* --- Custom Input Modal --- */
+/* Uses .modal-overlay and .modal-content styles already defined */
+/* Additional styling for the input modal specifically, if needed */
+#custom-input-modal .modal-content {
+    max-width: 400px; /* Or as desired */
+    height: auto;
+}
+
+#custom-input-modal .modal-body {
+    padding: 1.5rem;
+    flex-direction: column; /* Ensure items stack vertically */
+}
+
+#custom-input-modal-label {
+    margin-bottom: 0.5rem;
+    display: block; /* Ensure it takes full width */
+    font-weight: 500; /* Make label a bit bolder */
+}
+
+#custom-input-modal-field {
+    margin-bottom: 1rem; /* Space between input and buttons */
+}
+
+#custom-input-modal .modal-body div { /* Targeting the button container */
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+
 /* --- Notifications --- */
 .notification-container {
     position: fixed;


### PR DESCRIPTION
- Created a new custom input modal using HTML, CSS, and JS.
- Modal matches existing app design and includes title, label, input field, and OK/Cancel buttons.
- Replaced browser prompt() calls for renaming chats and folders with the new custom modal.
- Ensured proper handling of input, cancellation, and submission via callbacks.
- Added user notifications for successful actions.