### PR TITLE
Fix: Correct viewBox attribute for trash icon SVG

### DIFF
--- a/script.js
+++ b/script.js
@@ -678,7 +678,7 @@ function renderApiKeyList() {
 
         const deleteBtn = document.createElement('button');
         deleteBtn.title = 'Delete';
-        deleteBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24" 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>`;
+        deleteBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>`;
         deleteBtn.onclick = (e) => {
             e.stopPropagation();
             if (confirm(`Are you sure you want to delete the key "${key.name}"?`)) {


### PR DESCRIPTION
The trash icon SVG in the API key settings had a typo in its viewBox attribute, causing it to render incorrectly.

This commit corrects the typo from `viewBox="0 0 24" 24""` to `viewBox="0 0 24 24"`, ensuring the icon displays as intended.