### PR TITLE
fix: Use static script for Gemini SDK import

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,7 @@
             });
         }
     </script>
+    <script src="https://cdn.jsdelivr.net/npm/@google/generative-ai@latest/dist/index.min.js"></script>
     <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,6 @@ const config = {
     defaultLogLevel: 'info',
     dbName: 'gChatDB',
     dbVersion: 1, // Remember to increment this if you change DB schema with new stores/indexes
-    geminiApiUrl: 'https://esm.run/@google/generative-ai'
 };
 
 const state = {
@@ -918,8 +917,7 @@ async function getAIResponse(apiKey) {
     dom.chatWindow.scrollTop = dom.chatWindow.scrollHeight;
 
     try {
-        // Dynamically import the SDK
-        const { GoogleGenerativeAI } = await import(config.geminiApiUrl);
+        // The SDK is now loaded from a script tag in index.html
         const genAI = new GoogleGenerativeAI(apiKey);
 
         // Get generation config from UI


### PR DESCRIPTION
Replaces the dynamic import of the Google Generative AI SDK from esm.run with a static script tag in index.html pointing to a reliable CDN. This resolves a CORS-related error ('Failed to fetch dynamically imported module') that occurred when the app was hosted. This change makes the library loading more robust and less prone to issues with cross-origin requests or third-party CDN availability.