### PR TITLE
fix: Defer script initialization to prevent race condition

### DIFF
--- a/script.js
+++ b/script.js
@@ -2252,5 +2252,5 @@ async function handleImportChats(event) {
 }
 
 
-// Start the application
-initializeApp();
+// Start the application once the DOM is fully loaded
+document.addEventListener('DOMContentLoaded', initializeApp);


### PR DESCRIPTION
Wraps the initializeApp() call in a DOMContentLoaded event listener. This ensures that the main application script only executes after the DOM is fully parsed and all scripts, including the externally loaded Gemini SDK, are ready. This resolves a ReferenceError where GoogleGenerativeAI was not defined at the time of its call.