### PR TITLE
fix: Use correct browser bundle for Gemini SDK

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
             });
         }
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@google/generative-ai@latest/dist/index.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@google/generative-ai@latest/web/index.js"></script>
     <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Replaces the previously used CDN link for the Google Generative AI SDK, which pointed to a CommonJS build, with the correct link to the browser-specific bundle (web/index.js). This resolves the 'Uncaught ReferenceError: exports is not defined' error that occurred on application load.