### PR TITLE
fix: Revert to dynamic import with new CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,6 @@
             });
         }
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@google/generative-ai@latest/web/index.js"></script>
     <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ const config = {
     defaultLogLevel: 'info',
     dbName: 'gChatDB',
     dbVersion: 1, // Remember to increment this if you change DB schema with new stores/indexes
+    geminiApiUrl: 'https://unpkg.com/@google/generative-ai@latest/dist/index.js?module'
 };
 
 const state = {
@@ -917,7 +918,8 @@ async function getAIResponse(apiKey) {
     dom.chatWindow.scrollTop = dom.chatWindow.scrollHeight;
 
     try {
-        // The SDK is now loaded from a script tag in index.html
+        // Dynamically import the SDK
+        const { GoogleGenerativeAI } = await import(config.geminiApiUrl);
         const genAI = new GoogleGenerativeAI(apiKey);
 
         // Get generation config from UI
@@ -2252,5 +2254,5 @@ async function handleImportChats(event) {
 }
 
 
-// Start the application once the DOM is fully loaded
-document.addEventListener('DOMContentLoaded', initializeApp);
+// Start the application
+initializeApp();


### PR DESCRIPTION
Reverts the SDK loading mechanism back to a dynamic import() from a <script> tag approach.

- The static <script> tag caused various loading and scope issues (exports is not defined, ReferenceError).
- This change uses unpkg.com as the CDN for the ES module, which should be more reliable than the previously used esm.run and avoid the original 'Failed to fetch' error.