### PR TITLE
fix: Use default export for GoogleGenerativeAI constructor

### DIFF
--- a/script.js
+++ b/script.js
@@ -919,7 +919,7 @@ async function getAIResponse(apiKey) {
 
     try {
         // Dynamically import the SDK
-        const { GoogleGenerativeAI } = await import(config.geminiApiUrl);
+        const GoogleGenerativeAI = (await import(config.geminiApiUrl)).default;
         const genAI = new GoogleGenerativeAI(apiKey);
 
         // Get generation config from UI


### PR DESCRIPTION
Fixes a TypeError where GoogleGenerativeAI was not a constructor by using the default export from the imported module.