### PR TITLE
fix: Use correct CDN URL and import for @google/genai

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const config = {
     defaultLogLevel: 'info',
     dbName: 'gChatDB',
     dbVersion: 1, // Remember to increment this if you change DB schema with new stores/indexes
-    geminiApiUrl: 'https://unpkg.com/@google/genai?module'
+    geminiApiUrl: 'https://cdn.jsdelivr.net/npm/@google/genai/+esm'
 };
 
 const state = {
@@ -919,7 +919,7 @@ async function getAIResponse(apiKey) {
 
     try {
         // Dynamically import the SDK
-        const GoogleGenerativeAI = (await import(config.geminiApiUrl)).default;
+        const { GoogleGenerativeAI } = await import(config.geminiApiUrl);
         const genAI = new GoogleGenerativeAI(apiKey);
 
         // Get generation config from UI


### PR DESCRIPTION
This PR corrects the SDK import to resolve the final set of errors.\n\n- Updates the CDN URL to the correct jsDelivr ESM endpoint for `@google/genai`.\n- Changes the dynamic import to use a named export `{ GoogleGenerativeAI }` which is the correct syntax for this module.\n\nThis should resolve the `TypeError: GoogleGenerativeAI is not a constructor` and finally fix the chat functionality.