### PR TITLE
fix: Force global SDK availability to resolve constructor error

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,10 @@
             });
         }
     </script>
+    <script type="module">
+      import { GoogleGenerativeAI } from 'https://cdn.jsdelivr.net/npm/@google/genai/+esm';
+      window.GoogleGenerativeAI = GoogleGenerativeAI;
+    </script>
     <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,6 @@ const config = {
     defaultLogLevel: 'info',
     dbName: 'gChatDB',
     dbVersion: 1, // Remember to increment this if you change DB schema with new stores/indexes
-    geminiApiUrl: 'https://cdn.jsdelivr.net/npm/@google/genai/+esm'
 };
 
 const state = {
@@ -918,9 +917,8 @@ async function getAIResponse(apiKey) {
     dom.chatWindow.scrollTop = dom.chatWindow.scrollHeight;
 
     try {
-        // Dynamically import the SDK
-        const { GoogleGenerativeAI } = await import(config.geminiApiUrl);
-        const genAI = new GoogleGenerativeAI(apiKey);
+        // The SDK is now loaded via a script tag in index.html and attached to the window
+        const genAI = new window.GoogleGenerativeAI(apiKey);
 
         // Get generation config from UI
         const generationConfig = {


### PR DESCRIPTION
This PR implements a workaround for the 'GoogleGenerativeAI is not a constructor' error by explicitly importing the SDK in index.html and attaching it to the global window object.